### PR TITLE
Get rid of mmt-gensym

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *-autoloads.el
 *.elc
 *~
+
+/.cask/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ write macros with convenience.
 
 The following functions and macros are present:
 
-* `mmt-gensym`
 * `mmt-make-gensym-list`
 * `mmt-with-gensyms`
 * `mmt-with-unique-names`
@@ -36,28 +35,7 @@ The library is available on MELPA and MELPA stable.
 
 ## API
 
-```
-mmt-gensym &optional x
-```
-
-Create and return new uninterned symbol as if by calling `make-symbol`.
-
-The only difference between `mmt-gensym` and `make-symbol` is in how the new
-symbol's name is determined. The name is concatenation of a prefix which
-defaults to `"G"` and a suffix which is decimal representation of a number
-that defaults to the value of `mmt--gensym-counter`.
-
-If `x` is supplied and is a string, then that string is used as a prefix
-instead of `"G"` for this call to `mmt-gensym` only.
-
-If `x` is supplied and is an integer, then that integer is used instead of
-the value of `mmt--gensym-counter` as the suffix for this call of
-`mmt-gensym` only.
-
-If and only if no explicit suffix is supplied `mmt--gensym-counter` is
-incremented after it is used.
-
-----
+`cl-gensym` is provided by `cl-lib`, which ships with Emacs.
 
 ```
 mmt-make-gensym-list length &optional x

--- a/mmt.el
+++ b/mmt.el
@@ -66,8 +66,8 @@ If and only if no explicit suffix is supplied
   "Return a list of LENGTH gensyms.
 
 Each element of the list is generated as if with a call to
-`mmt-gensym' using the second argument X (defaulting \"G\")."
-  (mapcar #'mmt-gensym (make-list length (or x "G"))))
+`cl-gensym' using the second argument X (defaulting \"G\")."
+  (mapcar #'cl-gensym (make-list length (or x "G"))))
 
 (defmacro mmt-with-gensyms (names &rest body)
   "Bind each variable in NAMES to a unique symbol and evaluate BODY.
@@ -81,7 +81,7 @@ Bare symbols appearing in NAMES are equivalent to:
   (SYMBOL SYMBOL)
 
 The STRING-OR-SYMBOL is used (converted to string if necessary)
-as the argument to `mmt-gensym' when constructing the unique
+as the argument to `cl-gensym' when constructing the unique
 symbol the named variable will be bound to."
   (declare (indent 1))
   `(let ,(mapcar (lambda (name)
@@ -90,7 +90,7 @@ symbol the named variable will be bound to."
                            (cons (car name) (cadr name))
                          (cons name name))
                      `(,symbol
-                       (mmt-gensym
+                       (cl-gensym
                         ,(if (symbolp prefix)
                              (symbol-name prefix)
                            prefix)))))

--- a/mmt.el
+++ b/mmt.el
@@ -41,7 +41,7 @@
 ;; Note that this code is much inspired by relevant pieces from Common Lisp
 ;; library Alexandria.
 
-(require 'cl-lib)
+(eval-when-compile (require 'cl-lib))
 
 (defalias 'mmt-gensym 'cl-gensym
   "Create and return new uninterned symbol as if by calling `make-symbol'.

--- a/mmt.el
+++ b/mmt.el
@@ -30,7 +30,6 @@
 ;;
 ;; The following functions and macros are present:
 ;;
-;; * mmt-gensym
 ;; * mmt-make-gensym-list
 ;; * mmt-with-gensyms
 ;; * mmt-with-unique-names
@@ -42,25 +41,6 @@
 ;; library Alexandria.
 
 (eval-when-compile (require 'cl-lib))
-
-(defalias 'mmt-gensym 'cl-gensym
-  "Create and return new uninterned symbol as if by calling `make-symbol'.
-
-The only difference between `mmt-gensym' and `make-symbol' is in
-how the new symbol's name is determined.  The name is
-concatenation of a prefix which defaults to \"G\" and a suffix
-which is decimal representation of a number that defaults to the
-value of `cl--gensym-counter'.
-
-If X is supplied and is a string, then that string is used as a
-prefix instead of \"G\" for this call to `mmt-gensym' only.
-
-If X is supplied and is an integer, then that integer is used
-instead of the value of `cl--gensym-counter' as the suffix for
-this call of `mmt-gensym' only.
-
-If and only if no explicit suffix is supplied
-`cl--gensym-counter' is incremented after it is used.")
 
 (defun mmt-make-gensym-list (length &optional x)
   "Return a list of LENGTH gensyms.

--- a/test/mmt-test.el
+++ b/test/mmt-test.el
@@ -31,12 +31,6 @@
 (require 'mmt)
 (require 'cl-lib)
 
-;; `mmt-gensym'
-
-(ert-deftest mmt-gensym/aliasing ()
-  (should (eq (symbol-function 'mmt-gensym)
-              'cl-gensym)))
-
 ;; `mmt-make-gensym-list'
 
 (ert-deftest mmt-make-gensym-list/equality ()


### PR DESCRIPTION
This is identical to cl-gensym in cl-lib, which ships with Emacs.
There’s no need to provide duplicate names for this within the Emacs
Lisp community.

This allows mmt users to skip loading mmt at runtime, and allows mmt itself to skip loading cl-lib at runtime.